### PR TITLE
fix callbacks depricated in jquery 3.0

### DIFF
--- a/src/widgets/nestable/Nestable.php
+++ b/src/widgets/nestable/Nestable.php
@@ -206,16 +206,18 @@ class Nestable extends Widget
         $pluginOptions = $this->getPluginOptions();
         $pluginOptions = Json::encode($pluginOptions);
         $view->registerJs("$('#{$this->id}').nestable({$pluginOptions});");
+        // language=JavaScript
         $view->registerJs("
 			$('#{$this->id}-new-node-form').on('beforeSubmit', function(e){
                 $.ajax({
                     url: '{$this->getPluginOptions('createUrl')}',
                     method: 'POST',
-                    data: $(this).serialize()
-                }).success(function (data, textStatus, jqXHR) {
-                    $('#{$this->id}-new-node-modal').modal('hide')
-                    $.pjax.reload({container: '#{$this->id}-pjax'});
-                    window.scrollTo(0, document.body.scrollHeight);
+                    data: $(this).serialize(),
+                    success: function(data, textStatus, jqXHR) {
+	                    $('#{$this->id}-new-node-modal').modal('hide')
+	                    $.pjax.reload({container: '#{$this->id}-pjax'});
+	                    window.scrollTo(0, document.body.scrollHeight);
+                    },
                 }).fail(function (jqXHR) {
                     alert(jqXHR.responseText);
                 });

--- a/src/widgets/nestable/assets/jquery.nestable.js
+++ b/src/widgets/nestable/assets/jquery.nestable.js
@@ -354,9 +354,10 @@
                     parent_id: $(parent).data('id'),
                     prev_id: (prev.length ? prev.data('id') : 0),
                     next_id: (next.length ? next.data('id') : 0)
-                }
-            }).success(function () {
-                $.pjax.reload({container: '#' + tree.el.attr('id') + '-pjax'});
+                },
+                success: function () {
+                    $.pjax.reload({container: '#' + tree.el.attr('id') + '-pjax'});
+                },
             }).fail(function (jqXHR) {
                 alert(jqXHR.responseText);
             });
@@ -372,9 +373,10 @@
             $.ajax({
                 url: this.options.deleteUrl + '?id=' + id,
                 method: 'POST',
-                context: document.body
-            }).success(function (data, textStatus, jqXHR) {
-                $.pjax.reload({container: '#' + tree.el.attr('id') + '-pjax'});
+                context: document.body,
+	            success: function () {
+                    $.pjax.reload({container: '#' + tree.el.attr('id') + '-pjax'});
+                },
             }).fail(function (jqXHR) {
                 alert(jqXHR.responseText);
             });
@@ -396,11 +398,12 @@
                 context: document.body,
                 data: {
                     name: name.val()
-                }
-            }).success(function (data, textStatus, jqXHR) {
-                var editPanel = el.children('.' + tree.options.editPanelClass);
-                editPanel.removeClass(tree.options.inputOpenClass);
-                editPanel.slideUp(100);
+                },
+	            success: function () {
+                    var editPanel = el.children('.' + tree.options.editPanelClass);
+                    editPanel.removeClass(tree.options.inputOpenClass);
+                    editPanel.slideUp(100);
+                },
             }).fail(function (jqXHR) {
                 alert(jqXHR.responseText);
             });


### PR DESCRIPTION
The jqXHR.success(), jqXHR.error(), and jqXHR.complete() callbacks are [removed](http://api.jquery.com/jquery.ajax/) as of jQuery 3.0. This lead to error: **Uncaught TypeError: $.ajax(…).success is not a function** when using with jQuery 3.0
also see issue #9 